### PR TITLE
Reduce image size; fix typo in page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3pro.css">
     <link rel="stylesheet" href="https://www.w3schools.com/w3css/4/w3.css">
-    <title>UWB Hackatathon Coming Soon</title>
+    <title>UWB Hackathon Coming Soon</title>
     <link rel="stylesheet" href="styles.css">
 
 </head>


### PR DESCRIPTION
Image size went from 6.7MB to 1.6MB; pixel ratio went from 3800x5700 to 1200x1800, which should be fine for most displays. Used http://www.imageoptimizer.net/ and https://compressor.io/ to compress file.

Suggestions for additional compression are welcome! 

Here's the page load report from Pingdom before this PR (looking forward to comparing after PR gets merged): 
![pingdom_initial](https://user-images.githubusercontent.com/29528527/74109920-acf3c800-4b3c-11ea-8aff-00269fcbffc7.png)
